### PR TITLE
added weekly digest action

### DIFF
--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -1,0 +1,7 @@
+# Configuration for weekly-digest - https://github.com/apps/weekly-digest
+publishDay: sun
+canPublishIssues: true
+canPublishPullRequests: true
+canPublishContributors: true
+canPublishStargazers: true
+canPublishCommits: true 


### PR DESCRIPTION
Action to do weekly digest. In short get summary of everything that happened in a week on the repo!!! (Info about PR's , Issues etc and etc)

NOTE: The file needs to be in root .github itself, please don't move it to workflows as it will fail.
It is the config file for probot info through which the actions will run itself!!!
This will need bots to run correctly!