### PR TITLE
added GitHub Actions to skip based on commit message

### DIFF
--- a/.github/message.yml
+++ b/.github/message.yml
@@ -1,0 +1,5 @@
+jobs:
+  main:
+    name: Build and test
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"


### PR DESCRIPTION
If the last commit message contains the string skip-ci, the action will stop.

If a commit message contains a string defined as the environment variable $COMMIT_FILTER, the action will stop.