### PR TITLE
added debug github action

### DIFF
--- a/.github/sebug.yml
+++ b/.github/sebug.yml
@@ -1,0 +1,26 @@
+-- Environment variables ----------------------------------------------
+SECRET_TOKEN=[FILTERED]
+HOSTNAME=cdca0460a2e8
+SHLVL=1
+HOME=/github/home
+GITHUB_EVENT_PATH=/github/workflow/event.json
+GITHUB_WORKFLOW=New workflow
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+GITHUB_ACTION=hmarr/debug-action
+GITHUB_REPOSITORY=hmarr/some-repository
+GITHUB_WORKSPACE=/github/workspace
+GITHUB_SHA=2b337df5ad49034668adfa8f7d69120bb844eb96
+GITHUB_ACTOR=hmarr
+GITHUB_REF=refs/heads/some-branch
+PWD=/github/workspace
+GITHUB_EVENT_NAME=pull_request
+-----------------------------------------------------------------------
+
+-- Event JSON ---------------------------------------------------------
+{
+  "action": "opened",
+  "number": 10,
+  "pull_request": {
+  ...
+  }
+}


### PR DESCRIPTION
Print the environment variables and the event payload. Useful for developing or debugging GitHub Actions.

Secrets are automatically filtered in the Actions logs.