### PR TITLE
added autolabel action

### DIFF
--- a/.github/autolabel.yml
+++ b/.github/autolabel.yml
@@ -1,0 +1,9 @@
+workflow "issues" {
+  on = "issues"
+  resolves = ["autolabel"]
+}
+
+action "autolabel" {
+  uses = "brxxn/autolabel@release"
+  secrets = ["GITHUB_TOKEN"]
+}


### PR DESCRIPTION
This closes issues automatically if they don't use a bracket with a label in front of their post. The label is automatically assigned to the issue. It works on both pull requests and issues, but it can be changed to disable it.